### PR TITLE
Refine demo modal layout and FAQ styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+npm-debug.log*
+.DS_Store

--- a/src/components/FAQSection.tsx
+++ b/src/components/FAQSection.tsx
@@ -41,23 +41,21 @@ const FAQSection = () => {
             </p>
           </div>
 
-            <Accordion type="single" collapsible className="space-y-4">
-              {faqs.map((faq, index) => (
-                <AccordionItem 
-                  key={index} 
-                  value={`item-${index}`}
-                  className="bg-card/50 backdrop-blur-sm border border-border/50 rounded-lg px-6 data-[state=open]:shadow-medium transition-all duration-300"
-                >
-                  <AccordionTrigger className="text-left hover:text-ibuild-red transition-colors hover:no-underline py-6 [&[data-state=open]>svg]:rotate-180">
-                    <span className="text-lg font-semibold">{faq.question}</span>
-                  </AccordionTrigger>
-                  <AccordionContent className="pb-6">
-                    <p className="text-muted-foreground text-base leading-relaxed">
-                      {faq.answer}
-                    </p>
-                  </AccordionContent>
-                </AccordionItem>
-              ))}
+          <Accordion type="single" collapsible className="space-y-4">
+            {faqs.map((faq, index) => (
+              <AccordionItem
+                key={index}
+                value={`item-${index}`}
+                className="rounded-lg border border-gray-200 bg-gray-50 px-6 dark:border-gray-700 dark:bg-gray-800 data-[state=open]:shadow-md"
+              >
+                <AccordionTrigger className="text-left py-5 text-lg font-semibold text-gray-900 transition-colors hover:no-underline dark:text-gray-100 [&[data-state=open]>svg]:rotate-180">
+                  {faq.question}
+                </AccordionTrigger>
+                <AccordionContent className="pb-5 text-base leading-relaxed text-gray-700 dark:text-gray-300">
+                  {faq.answer}
+                </AccordionContent>
+              </AccordionItem>
+            ))}
           </Accordion>
         </div>
       </div>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -34,11 +34,21 @@ const HeroSection = () => {
 
             {/* CTA Buttons */}
             <div className="flex flex-col sm:flex-row gap-4">
-              <Button variant="ibuild-outline" size="lg" className="group" onClick={openDemo}>
+              <Button
+                variant="ibuild-outline"
+                size="lg"
+                className="group w-full sm:w-auto"
+                onClick={openDemo}
+              >
                 <Phone className="h-5 w-5 mr-2 group-hover:rotate-12 transition-transform" />
                 Schedule a Demo
               </Button>
-              <Button asChild variant="ibuild-primary" size="lg" className="group">
+              <Button
+                asChild
+                variant="ibuild-primary"
+                size="lg"
+                className="group w-full sm:w-auto"
+              >
                 <Link to="/plans">
                   <Rocket className="h-5 w-5 mr-2 group-hover:translate-x-1 transition-transform" />
                   Start Building with iBUILD Today

--- a/src/components/layout/DemoModal.tsx
+++ b/src/components/layout/DemoModal.tsx
@@ -63,19 +63,18 @@ export const DemoModal = ({ isOpen, onClose }: DemoModalProps) => {
   };
 
   return (
-    <div className="fixed inset-0 z-[100]">
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 sm:p-6">
       {/* Backdrop */}
       <div className="absolute inset-0 bg-black/60" onClick={onClose} />
 
       {/* Centered dialog */}
-      <div className="absolute inset-0 flex items-center justify-center p-4 sm:p-6">
-        <div
-          ref={panelRef}
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="demoModalTitle"
-          className="w-full max-w-4xl rounded-2xl bg-white text-gray-900 shadow-2xl overflow-hidden"
-        >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="demoModalTitle"
+        className="relative w-full max-w-4xl rounded-2xl bg-white text-gray-900 shadow-2xl overflow-hidden"
+      >
           {/* Header */}
           <div className="px-6 py-5 border-b bg-gray-50 flex items-center justify-between">
             <h3 id="demoModalTitle" className="text-lg sm:text-xl font-semibold">Send your demo request !</h3>
@@ -141,7 +140,6 @@ export const DemoModal = ({ isOpen, onClose }: DemoModalProps) => {
             )}
           </div>
         </div>
-      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Center demo modal on screen for Book a Demo interactions
- Make hero CTA buttons responsive and link to pricing page
- Restyle FAQ section with light/dark accordion design

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c09334c3c0832fb257bc8c925dcdff