### PR TITLE
Use arrow image in FAQ section with light and dark mode support

### DIFF
--- a/src/assets/faq-arrow.svg
+++ b/src/assets/faq-arrow.svg
@@ -1,0 +1,4 @@
+<svg width="120" height="160" viewBox="0 0 120 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M10 20 C -10 80 70 80 30 120 C 0 150 60 160 90 140" stroke="#d7352f" stroke-width="6" fill="none" />
+  <path d="M80 130 L110 150 L100 120" stroke="#d7352f" stroke-width="6" fill="none" />
+</svg>

--- a/src/components/FAQSection.tsx
+++ b/src/components/FAQSection.tsx
@@ -1,5 +1,6 @@
 import * as Accordion from "@radix-ui/react-accordion";
 import { ChevronRight } from "lucide-react";
+import faqArrow from "@/assets/faq-arrow.svg";
 
 const FAQSection = () => {
   const faqs = [
@@ -31,28 +32,11 @@ const FAQSection = () => {
 
   return (
     <section className="relative py-24 bg-gray-50 dark:bg-background">
-      <svg
-        aria-hidden="true"
-        viewBox="0 0 100 100"
-        className="hidden md:block absolute left-0 top-1/2 w-24 h-24 -translate-x-1/2 -translate-y-1/2 text-ibuild-red"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M5 60C20 20 80 20 95 60"
-          stroke="currentColor"
-          strokeWidth="8"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        <path
-          d="M75 52L95 60L85 40"
-          stroke="currentColor"
-          strokeWidth="8"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </svg>
+      <img
+        src={faqArrow}
+        alt=""
+        className="pointer-events-none select-none hidden md:block absolute left-0 top-1/2 w-40 -translate-x-1/2 -translate-y-1/2"
+      />
       <div className="container max-w-screen-2xl">
         <div className="relative max-w-4xl mx-auto">
           <div className="text-center mb-16">


### PR DESCRIPTION
## Summary
- replace SVG arrow with decorative image asset in FAQ section
- ensure FAQ section supports both light and dark modes

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3bdb01134832fad37b2c4d66b0327