### PR TITLE
Add contact page route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Plans from "./pages/Plans";
 import Support from "./pages/Support";
 import ChatButton from "@/components/ChatButton";
 import Tools from "./pages/Tools";
+import Contact from "./pages/Contact";
 
 const queryClient = new QueryClient();
 
@@ -24,6 +25,7 @@ const App = () => (
             <Route path="/" element={<Index />} />
             <Route path="/tools" element={<Tools />} />
             <Route path="/plans" element={<Plans />} />
+            <Route path="/contact" element={<Contact />} />
             <Route path="/support" element={<Support />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -51,7 +51,7 @@ const Header = () => {
     { name: "Tools", href: "/tools" },
     { name: "Plans & Pricing", href: "/plans" },
     { name: "Support", href: "/support" },
-    { name: "Contact", href: "#contact" },
+    { name: "Contact", href: "/contact" },
     { name: "Log In", href: "#login" },
   ];
 
@@ -132,7 +132,7 @@ const Header = () => {
             <Link to="/support">Support</Link>
           </Button>
           <Button variant="ibuild-nav" asChild>
-            <a href="#contact">Contact</a>
+            <Link to="/contact">Contact</Link>
           </Button>
           <Button variant="ibuild-nav" asChild>
             <a href="#login">Log In</a>
@@ -151,7 +151,7 @@ const Header = () => {
             <Link to="/plans">Pricing</Link>
           </Button>
           <Button variant="ibuild-nav" className="text-xs px-1" asChild>
-            <a href="#contact">Contact</a>
+            <Link to="/contact">Contact</Link>
           </Button>
           <ThemeToggle />
           <Button variant="ibuild-primary" size="sm" className="text-xs px-2 whitespace-nowrap" onClick={() => setIsDemoOpen(true)}>
@@ -181,7 +181,11 @@ const Header = () => {
           <nav className="container max-w-screen-2xl py-4 grid gap-2">
             {navItems.map((item) => (
               <Button key={item.name} variant="ghost" className="justify-start" asChild>
-                <a href={item.href}>{item.name}</a>
+                {item.href.startsWith('/') ? (
+                  <Link to={item.href}>{item.name}</Link>
+                ) : (
+                  <a href={item.href}>{item.name}</a>
+                )}
               </Button>
             ))}
             <div className="pt-2">


### PR DESCRIPTION
## Summary
- add Contact page to app router
- wire header Contact link to the Contact route and handle internal links in the mobile menu

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3e291bf80832f99177129a4cf5138