### PR TITLE
feat: add dedicated projects page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Support from "./pages/Support";
 import ChatButton from "@/components/ChatButton";
 import Tools from "./pages/Tools";
 import Contact from "./pages/Contact";
+import Projects from "./pages/Projects";
 import ScrollToTop from "@/components/layout/ScrollToTop";
 
 const queryClient = new QueryClient();
@@ -26,6 +27,7 @@ const App = () => (
           <Routes>
             <Route path="/" element={<Index />} />
             <Route path="/tools" element={<Tools />} />
+            <Route path="/projects" element={<Projects />} />
             <Route path="/plans" element={<Plans />} />
             <Route path="/contact" element={<Contact />} />
             <Route path="/support" element={<Support />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -49,6 +49,7 @@ const Header = () => {
   const navItems = [
     { name: "Products", href: "#products" },
     { name: "Tools", href: "/tools" },
+    { name: "Projects", href: "/projects" },
     { name: "Plans & Pricing", href: "/plans" },
     { name: "Support", href: "/support" },
     { name: "Contact", href: "/contact" },
@@ -124,6 +125,9 @@ const Header = () => {
 
           <Button variant="ibuild-nav" asChild>
             <Link to="/tools">Tools</Link>
+          </Button>
+          <Button variant="ibuild-nav" asChild>
+            <Link to="/projects">Projects</Link>
           </Button>
           <Button variant="ibuild-nav" asChild>
             <Link to="/plans">Plans & Pricing</Link>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,7 +2,6 @@ import Header from "@/components/Header";
 import HeroSection from "@/components/HeroSection";
 import AboutSection from "@/components/AboutSection";
 import TestimonialsSection from "@/components/TestimonialsSection";
-import ProjectsSection from "@/components/ProjectsSection";
 import FeaturesSection from "@/components/FeaturesSection";
 import Footer from "@/components/Footer";
 
@@ -14,7 +13,6 @@ const Index = () => {
         <HeroSection />
         <AboutSection />
         <TestimonialsSection />
-        <ProjectsSection />
         <FeaturesSection />
       </main>
       <Footer />

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,0 +1,10 @@
+import AppLayout from "@/components/layout/AppLayout";
+import ProjectsSection from "@/components/ProjectsSection";
+
+export default function Projects() {
+  return (
+    <AppLayout>
+      <ProjectsSection />
+    </AppLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- create new `/projects` page housing the existing project showcase
- remove projects section from the landing page and wire new page into the router
- add "Projects" link to the site navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c404d9c20c832f8f8ede46f4910269