### PR TITLE
Revamp projects page by categories

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -86,9 +86,9 @@ const Header = () => {
                   <div>
                     <h4 className="font-semibold mb-3">Solutions</h4>
                     <ul className="space-y-2 text-sm">
-                      <li><a onClick={() => setIsProductsOpen(false)} href="#residential" className="hover:text-ibuild-red">Residential</a></li>
-                      <li><a onClick={() => setIsProductsOpen(false)} href="#multi-family" className="hover:text-ibuild-red">Multi-Family</a></li>
-                      <li><a onClick={() => setIsProductsOpen(false)} href="#land-development" className="hover:text-ibuild-red">Land Development</a></li>
+                      <li><a onClick={() => setIsProductsOpen(false)} href="/projects#residential" className="hover:text-ibuild-red">Residential</a></li>
+                      <li><a onClick={() => setIsProductsOpen(false)} href="/projects#multi-family" className="hover:text-ibuild-red">Multi-Family</a></li>
+                      <li><a onClick={() => setIsProductsOpen(false)} href="/projects#land-development" className="hover:text-ibuild-red">Land Development</a></li>
                     </ul>
                     <h4 className="font-semibold mt-6 mb-3">Communication Features</h4>
                     <ul className="space-y-2 text-sm">

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -1,13 +1,16 @@
-import { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel";
 
 import projectImg1 from "@/assets/projects/project-1.webp";
 import projectImg3 from "@/assets/projects/project-3.webp";
 import projectImg4 from "@/assets/projects/project-4.webp";
 import projectImg5 from "@/assets/projects/project-5.webp";
 import projectImg6 from "@/assets/projects/project-6.webp";
-import projectImg7 from "@/assets/projects/project-7.webp";
 import projectImg8 from "@/assets/projects/project-8.webp";
 import projectImg9 from "@/assets/projects/project-9.webp";
 import projectImg10 from "@/assets/projects/project-10.webp";
@@ -15,119 +18,237 @@ import projectImg11 from "@/assets/projects/project-11.webp";
 import projectImg12 from "@/assets/projects/project-12.webp";
 
 const ProjectsSection = () => {
-  const [activeFilter, setActiveFilter] = useState("Multi-Family");
-
-  const filters = ["Multi-Family", "Residential", "Communities"];
-
-  const projects = [
-    {
-      name: "Arbour Lake Project",
-      category: "Multi-Family",
-      image: projectImg1,
-    },
-    {
-      name: "Crimson Ridge Project", 
-      category: "Multi-Family",
-      image: projectImg3,
-    },
-    {
-      name: "Martindale Project",
-      category: "Communities",
-      image: projectImg4,
-    },
-    {
-      name: "Riverstone West Project",
-      category: "Communities", 
-      image: projectImg5,
-    },
-    {
-      name: "Sol Verda Chestermere",
-      category: "Residential",
-      image: projectImg6,
-    },
-    {
-      name: "Stanley Project",
-      category: "Residential",
-      image: projectImg8,
-    },
-    {
-      name: "Zen Abrio Project",
-      category: "Multi-Family",
-      image: projectImg9,
-    },
-    {
-      name: "Zen Chinook Gate",
-      category: "Multi-Family",
-      image: projectImg10,
-    },
-    {
-      name: "Zen Livingston",
-      category: "Multi-Family",
-      image: projectImg11,
-    },
-    {
-      name: "Zen Greystone",
-      category: "Multi-Family",
-      image: projectImg12,
-    }
+  const residentialImages = [projectImg6, projectImg8];
+  const multiFamilyImages = [
+    projectImg1,
+    projectImg3,
+    projectImg9,
+    projectImg10,
+    projectImg11,
+    projectImg12,
   ];
-
-  const filteredProjects = projects.filter(project => 
-    project.category === activeFilter || 
-    (activeFilter === "Communities" && project.category === "Communities")
-  );
+  const landDevelopmentImages = [projectImg4, projectImg5];
 
   return (
-    <section id="projects" className="py-24 bg-background">
-      <div className="container max-w-screen-2xl">
-        <div className="text-center mb-16">
-          <div className="inline-flex items-center gap-2 text-ibuild-red font-semibold mb-4">
-            <div className="w-8 h-px bg-ibuild-red"></div>
-            Our Projects
-          </div>
-          <h2 className="text-4xl lg:text-5xl font-bold text-foreground mb-6">
-            Clients Projects<span className="text-ibuild-red"> Recently Completed With iBUILD</span>
-          </h2>
-        </div>
-
-        {/* Filter Buttons */}
-        <div className="flex flex-wrap justify-center gap-8 mb-12">
-          {filters.map((filter) => (
-            <Button
-              key={filter}
-              variant={activeFilter === filter ? "ibuild-primary" : "ibuild-ghost"}
-              onClick={() => setActiveFilter(filter)}
-              className="transition-all duration-300"
-            >
-              {filter}
-            </Button>
-          ))}
-        </div>
-
-        {/* Projects Grid */}
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8">
-          {filteredProjects.map((project, index) => (
-            <Card key={index} className="group overflow-hidden border-border/50 hover:shadow-large transition-all duration-300">
-              <div className="relative overflow-hidden">
-                <img
-                  src={project.image}
-                  alt={project.name}
-                  className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300"
-                />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+    <section className="py-24 bg-background">
+      <div className="container max-w-screen-2xl space-y-24">
+        <div
+          id="residential"
+          className="grid gap-10 md:grid-cols-2 md:items-center"
+        >
+          <div>
+            <h2 className="text-4xl font-bold mb-6 text-foreground">
+              Single-Family Residential Builders
+            </h2>
+            <p className="text-muted-foreground mb-6">
+              BUILD understands and appreciates that homes are more than just
+              structures; they're heartwarming memories are made. At iBUILD, our
+              cloud software offers innovative solutions to bring your vision to
+              life.
+            </p>
+            <h3 className="text-2xl font-bold mb-4 text-foreground">
+              Project Flexibility
+            </h3>
+            <p className="text-muted-foreground mb-6">
+              When creating a single-family residential project, iBUILD provides
+              builders with total flexibility. You can choose from foundation
+              options and customizable parking solutions. Plus, our unique
+              Basement Development option allows you to personalize your project
+              even further.
+            </p>
+            <div className="grid md:grid-cols-2 gap-6 text-muted-foreground">
+              <div>
+                <h4 className="font-semibold mb-2">Foundation Options</h4>
+                <ul className="list-disc pl-5 space-y-1">
+                  <li>Basement</li>
+                  <li>Slab-On-Grade</li>
+                  <li>Crawl Space / Pile Columns</li>
+                </ul>
               </div>
-              <CardContent className="p-6">
-                <div className="mb-2">
-                  <span className="inline-block px-3 py-1 text-xs font-medium bg-ibuild-red/10 text-ibuild-red rounded-full">
-                    {project.category}
-                  </span>
-                </div>
-                <h3 className="text-xl font-bold text-foreground group-hover:text-ibuild-red transition-colors">
-                  {project.name}
-                </h3>
-              </CardContent>
-            </Card>
-          ))}
+              <div>
+                <h4 className="font-semibold mb-2">Parking Options</h4>
+                <ul className="list-disc pl-5 space-y-1">
+                  <li>Attached Garage</li>
+                  <li>Detached Garage (With or Without Secondary Suite)</li>
+                  <li>Carport</li>
+                  <li>Parking Pads</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div>
+            <Carousel opts={{ loop: true }} className="w-full">
+              <CarouselContent>
+                {residentialImages.map((image, idx) => (
+                  <CarouselItem key={idx}>
+                    <img
+                      src={image}
+                      alt="Residential project"
+                      className="w-full h-full object-cover rounded-lg"
+                    />
+                  </CarouselItem>
+                ))}
+              </CarouselContent>
+              <CarouselPrevious />
+              <CarouselNext />
+            </Carousel>
+          </div>
+        </div>
+
+        <div
+          id="multi-family"
+          className="grid gap-10 md:grid-cols-2 md:items-center"
+        >
+          <div>
+            <h2 className="text-4xl font-bold mb-6 text-foreground">
+              Multi-Family Residential Buildings
+            </h2>
+            <p className="text-muted-foreground mb-6">
+              From duplexes to wood-framed apartment buildings, iBUILD excels in
+              multi-unit residential projects. Our comprehensive approach covers
+              everything from blocks and units to common areas, amenities, and
+              complex reporting. What makes iBUILD stand out?
+            </p>
+            <h3 className="text-2xl font-bold mb-4 text-foreground">
+              Project Proforma Forecasting Module
+            </h3>
+            <p className="text-muted-foreground mb-6">
+              iBUILD stands out with a robust project proforma forecasting
+              module offering a Project Proforma Forecasting Module. This tool
+              not only estimates construction costs and durations but also
+              accelerates the progress of securing major project financing
+              through foundation offerings.
+            </p>
+            <div className="grid md:grid-cols-2 gap-6 text-muted-foreground">
+              <div>
+                <h4 className="font-semibold mb-2">Foundation Options</h4>
+                <ul className="list-disc pl-5 space-y-1">
+                  <li>Basement</li>
+                  <li>Slab-On-Grade</li>
+                  <li>Concrete Pile Columns</li>
+                  <li>Heated Underground Parkade</li>
+                  <li>Ground Level Parkade</li>
+                </ul>
+              </div>
+              <div>
+                <h4 className="font-semibold mb-2">Parking Options</h4>
+                <ul className="list-disc pl-5 space-y-1">
+                  <li>Attached Garage</li>
+                  <li>Detached Garage</li>
+                  <li>Carport</li>
+                  <li>Grade Level Parking Stalls / Pads</li>
+                  <li>
+                    Separate Standalone Ground Level Multi-Level Parkade
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div>
+            <Carousel opts={{ loop: true }} className="w-full">
+              <CarouselContent>
+                {multiFamilyImages.map((image, idx) => (
+                  <CarouselItem key={idx}>
+                    <img
+                      src={image}
+                      alt="Multi-family project"
+                      className="w-full h-full object-cover rounded-lg"
+                    />
+                  </CarouselItem>
+                ))}
+              </CarouselContent>
+              <CarouselPrevious />
+              <CarouselNext />
+            </Carousel>
+          </div>
+        </div>
+
+        <div
+          id="land-development"
+          className="grid gap-10 md:grid-cols-2 md:items-center"
+        >
+          <div>
+            <h2 className="text-4xl font-bold mb-6 text-foreground">
+              Land Development
+            </h2>
+            <p className="text-muted-foreground mb-6">
+              Whether it's developing a tract or section of land, iBUILD
+              empowers developers to break the land into parcels or phases.
+              Specify the number of lots in designated zoning areas to create
+              vibrant communities.
+            </p>
+            <h3 className="text-2xl font-bold mb-4 text-foreground">
+              iBUILD's Comprehensive Residential Land Development Sector
+              Components
+            </h3>
+            <p className="text-muted-foreground mb-6">
+              This comprehensive solution tracks land inventory and sales,
+              records lot conditions, and tracks development costs. iBUILD stores
+              and retrieves extensive and in-depth information and provides a
+              solid accounting integration.
+            </p>
+            <ul className="list-disc pl-5 space-y-1 text-muted-foreground">
+              <li>
+                Land Acquisition Costs: Strategically manage land and land
+                acquisition expenses.
+              </li>
+              <li>
+                Architects &amp; Consultants: Collaborate seamlessly with design
+                professionals.
+              </li>
+              <li>
+                Engineers: Engage expert engineers for technical
+                recommendations.
+              </li>
+              <li>Permits &amp; Fees: Track all necessary permits and fees.</li>
+              <li>
+                New Home Warranty &amp; Insurance Fees: Safeguard your project
+                with proper coverage.
+              </li>
+              <li>
+                Condominium Plan Corresponding Costs: Address
+                condominium-specific expenses.
+              </li>
+              <li>
+                Land Development Inspection Fees: Appropriately manage
+                inspections.
+              </li>
+              <li>
+                Management, Legal, Financing Fees: Secure financing and manage
+                credit effectively.
+              </li>
+              <li>
+                Municipal, School, and Recreational Servicing Costs: Understand
+                required infrastructure requirements.
+              </li>
+              <li>
+                Site Preparation &amp; Temp Office Costs: Prepare the site
+                efficiently.
+              </li>
+              <li>Site Landscaping Costs: Enhance aesthetics.</li>
+              <li>
+                iBUILD leaves no stone unturned, safeguarding successful project
+                outcomes.
+              </li>
+            </ul>
+          </div>
+          <div>
+            <Carousel opts={{ loop: true }} className="w-full">
+              <CarouselContent>
+                {landDevelopmentImages.map((image, idx) => (
+                  <CarouselItem key={idx}>
+                    <img
+                      src={image}
+                      alt="Land development project"
+                      className="w-full h-full object-cover rounded-lg"
+                    />
+                  </CarouselItem>
+                ))}
+              </CarouselContent>
+              <CarouselPrevious />
+              <CarouselNext />
+            </Carousel>
+          </div>
         </div>
       </div>
     </section>

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -22,9 +22,9 @@ export default function ProductsPage() {
 
           <div className="mt-8 grid gap-8 md:grid-cols-3">
             <Section title="Solutions">
-              <LinkItem href="/solutions#residential">Residential</LinkItem>
-              <LinkItem href="/solutions#multi-family">Multi-Family</LinkItem>
-              <LinkItem href="/solutions#land-development">Land Development</LinkItem>
+              <LinkItem href="/projects#residential">Residential</LinkItem>
+              <LinkItem href="/projects#multi-family">Multi-Family</LinkItem>
+              <LinkItem href="/projects#land-development">Land Development</LinkItem>
             </Section>
 
             <Section title="Communication Features">


### PR DESCRIPTION
## Summary
- refactor projects page into dedicated residential, multi-family, and land development sections with carousels
- wire up navigation links from product dropdown and products page to new sections

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c410228efc832fa5fda1f13116af33