### PR TITLE
Increase logo sizes in navigation and footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,7 +12,11 @@ const Footer = () => {
           <div>
             <div className="mb-6">
               <a href="/" className="block">
-                <img src={logoDark} alt="iBUILD Applications" className="h-10 w-auto" />
+                <img
+                  src={logoDark}
+                  alt="iBUILD Applications"
+                  className="h-16 w-auto sm:h-20 md:h-24"
+                />
               </a>
             </div>
             <p className="text-sm opacity-80">Follow</p>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -58,18 +58,18 @@ const Header = () => {
 
   return (
     <header className="sticky top-0 z-50 w-full bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b border-border/50">
-      <div className="container flex h-16 max-w-screen-2xl items-center justify-between xl:justify-start">
+      <div className="container flex h-20 max-w-screen-2xl items-center justify-between xl:justify-start">
         {/* Logo (clickable) */}
         <Link to="/" className="flex h-full items-center">
           <img
             src={logoLight}
             alt="iBUILD Applications"
-            className="block h-10 w-auto sm:h-11 md:h-12 lg:h-14 dark:hidden"
+            className="block h-16 w-auto sm:h-20 md:h-20 lg:h-20 dark:hidden"
           />
           <img
             src={logoDark}
             alt="iBUILD Applications"
-            className="hidden h-10 w-auto sm:h-11 md:h-12 lg:h-14 dark:block"
+            className="hidden h-16 w-auto sm:h-20 md:h-20 lg:h-20 dark:block"
           />
         </Link>
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -45,7 +45,12 @@ export const Footer = () => {
         <div className="row align-items-center">
           <div className="col-md-6">
             <div className="d-flex align-items-center mb-3 mb-md-0">
-              <img src={IMAGES.logo} alt="iBUILD" height="30" className="me-3" />
+              <img
+                src={IMAGES.logo}
+                alt="iBUILD"
+                className="me-3 img-fluid"
+                style={{ maxHeight: '60px', width: 'auto' }}
+              />
               <div className="d-flex gap-3">
                 <a href="#" className="text-light">
                   <img src={IMAGES.facebook} alt="Facebook" width="24" height="24" />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -29,7 +29,12 @@ export const Header = ({ onDemoClick }: HeaderProps) => {
     <nav className="navbar navbar-expand-lg navbar-dark bg-dark sticky-top">
       <div className="container-fluid">
         <Link className="navbar-brand d-flex align-items-center" to="/">
-          <img src={IMAGES.logo} alt="iBUILD" height="40" className="me-2" />
+          <img
+            src={IMAGES.logo}
+            alt="iBUILD"
+            className="me-2 img-fluid"
+            style={{ maxHeight: '60px', width: 'auto' }}
+          />
           <span className="fw-bold">iBUILD</span>
         </Link>
 


### PR DESCRIPTION
## Summary
- Enlarge header container and logos for better visibility with responsive sizing
- Scale footer logos up with responsive Tailwind classes
- Boost layout header/footer logo dimensions with fluid, max-height styling

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c434e1cecc832f96bd863741f06ea9