### PR TITLE
feat: enhance chat button responsiveness and greeting

### DIFF
--- a/src/components/ChatButton.tsx
+++ b/src/components/ChatButton.tsx
@@ -1,4 +1,4 @@
-import { useState, type KeyboardEvent } from "react";
+import { useEffect, useState, type KeyboardEvent } from "react";
 import {
   MessageCircle,
   Paperclip,
@@ -23,11 +23,6 @@ const ChatButton = () => {
     setMessages((prev) => [
       ...prev,
       { id: prev.length, from: "user", text: input },
-      {
-        id: prev.length + 1,
-        from: "bot",
-        text: "Hello, How can we help you today?",
-      },
     ]);
     setInput("");
   };
@@ -39,10 +34,18 @@ const ChatButton = () => {
     }
   };
 
+  useEffect(() => {
+    if (open && messages.length === 0) {
+      setMessages([
+        { id: 0, from: "bot", text: "Hello, How can we help you today?" },
+      ]);
+    }
+  }, [open, messages.length]);
+
   return (
     <>
       {open && (
-        <div className="fixed bottom-20 right-4 sm:bottom-24 sm:right-6 md:bottom-28 md:right-8 z-50 w-80 sm:w-96 bg-white border-2 border-ibuild-red rounded-lg shadow-soft flex flex-col">
+        <div className="fixed bottom-20 right-4 sm:bottom-24 sm:right-6 md:bottom-28 md:right-8 z-50 w-80 sm:w-96 bg-white dark:bg-ibuild-dark border-2 border-ibuild-red rounded-lg shadow-soft flex flex-col">
           <div className="flex items-center justify-between bg-ibuild-red text-white px-4 py-2 rounded-t-lg">
             <span>iBUILD Online Chat</span>
             <button
@@ -64,8 +67,8 @@ const ChatButton = () => {
                 <div
                   className={`rounded-lg px-3 py-2 text-sm max-w-[75%] ${
                     msg.from === "bot"
-                      ? "bg-ibuild-red text-white"
-                      : "bg-ibuild-light-gray"
+                      ? "bg-ibuild-red text-white dark:bg-ibuild-red"
+                      : "bg-ibuild-light-gray dark:bg-ibuild-darker dark:text-white"
                   }`}
                 >
                   {msg.text}
@@ -73,7 +76,7 @@ const ChatButton = () => {
               </div>
             ))}
           </div>
-          <div className="flex items-center gap-2 border-t p-2">
+          <div className="flex items-center gap-2 border-t dark:border-ibuild-darker p-2">
             <button aria-label="Add attachment" className="text-ibuild-red">
               <Paperclip className="w-5 h-5" />
             </button>
@@ -86,7 +89,7 @@ const ChatButton = () => {
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder="Ask your Question?"
-              className="flex-1 border rounded px-2 py-1 text-sm focus:outline-none"
+              className="flex-1 border rounded px-2 py-1 text-sm focus:outline-none dark:bg-ibuild-darker dark:border-ibuild-gray dark:text-white"
             />
             <button
               onClick={handleSend}
@@ -101,7 +104,7 @@ const ChatButton = () => {
       <button
         aria-label="Chat with us"
         onClick={() => setOpen(!open)}
-        className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 md:bottom-8 md:right-8 z-50 flex items-center justify-center rounded-full bg-white border-2 border-ibuild-red shadow-soft w-12 h-12 sm:w-14 sm:h-14 md:w-16 md:h-16"
+        className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 md:bottom-8 md:right-8 z-50 flex items-center justify-center rounded-full bg-white dark:bg-ibuild-dark border-2 border-ibuild-red shadow-soft w-12 h-12 sm:w-14 sm:h-14 md:w-16 md:h-16"
       >
         <MessageCircle
           className="w-6 h-6 sm:w-7 sm:h-7 md:w-8 md:h-8 text-ibuild-red"


### PR DESCRIPTION
## Summary
- greet users with "Hello, How can we help you today?" when opening the chat
- adjust chat window and trigger button styles for dark theme responsiveness

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c471f1c20c832fa33f2bd2c0cce53c