### PR TITLE
Remove duplicate logo from chat button

### DIFF
--- a/src/components/ChatButton.tsx
+++ b/src/components/ChatButton.tsx
@@ -53,17 +53,6 @@ const ChatButton = () => {
               <img
                 src={logoLight}
                 alt="iBUILD Applications"
-                className="h-6 w-auto dark:hidden"
-              />
-              <img
-                src={logoDark}
-                alt="iBUILD Applications"
-                className="hidden h-6 w-auto dark:block"
-              />
-            <div className="flex items-center gap-2">
-              <img
-                src={logoLight}
-                alt="iBUILD Applications"
                 className="h-8 w-auto sm:h-10 dark:hidden"
               />
               <img
@@ -72,7 +61,6 @@ const ChatButton = () => {
                 className="hidden h-8 w-auto sm:h-10 dark:block"
               />
               <span>iBUILD Online Chat</span>
-            </div>
             </div>
             <button
               onClick={() => setOpen(false)}


### PR DESCRIPTION
## Summary
- Remove extra small logo in chat widget header, keeping larger version

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4a45e1e5c832f9373c03a7ccbadf8