### PR TITLE
feat: showcase experience with hanging sign

### DIFF
--- a/src/components/ExperienceSign.tsx
+++ b/src/components/ExperienceSign.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+
+const ExperienceSign = () => (
+  <svg
+    viewBox="0 0 200 150"
+    className="mx-auto mt-8 h-36 w-52"
+    role="img"
+    aria-label="35+ Years Industry Experience"
+  >
+    <line x1="100" y1="10" x2="40" y2="40" stroke="hsl(var(--border))" strokeWidth="2" />
+    <line x1="100" y1="10" x2="160" y2="40" stroke="hsl(var(--border))" strokeWidth="2" />
+    <circle cx="100" cy="10" r="4" fill="hsl(var(--border))" />
+    <rect
+      x="40"
+      y="40"
+      width="120"
+      height="90"
+      rx="8"
+      fill="hsl(var(--card))"
+      stroke="hsl(var(--border))"
+      strokeWidth="2"
+    />
+    <text
+      x="100"
+      y="82"
+      textAnchor="middle"
+      fontSize="32"
+      fontWeight="700"
+      fill="hsl(var(--ibuild-red))"
+    >
+      35+
+    </text>
+    <text
+      x="100"
+      y="106"
+      textAnchor="middle"
+      fontSize="14"
+      fontWeight="600"
+      fill="hsl(var(--muted-foreground))"
+    >
+      Years
+    </text>
+    <text
+      x="100"
+      y="124"
+      textAnchor="middle"
+      fontSize="14"
+      fontWeight="600"
+      fill="hsl(var(--foreground))"
+    >
+      Industry Experience
+    </text>
+  </svg>
+);
+
+export default ExperienceSign;
+

--- a/src/components/FeaturesSection.tsx
+++ b/src/components/FeaturesSection.tsx
@@ -1,8 +1,9 @@
-aimport { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { TrendingUp, Settings, DollarSign, MessageCircle } from "lucide-react";
 import { Link } from "react-router-dom";
 import constructionDashboard from "@/assets/construction-dashboard.png";
+import ExperienceSign from "@/components/ExperienceSign";
 
 const FeaturesSection = () => {
   const openDemo = () => {
@@ -81,13 +82,7 @@ const FeaturesSection = () => {
             </div>
 
             {/* Experience Badge */}
-            <div className="inline-flex items-center gap-3 bg-gradient-card rounded-2xl p-4 border border-border/50">
-              <div className="text-center">
-                <div className="text-2xl font-bold text-ibuild-red">35+</div>
-                <div className="text-xs text-muted-foreground font-medium">years</div>
-              </div>
-              <div className="text-sm font-medium text-foreground">Industry Experience</div>
-            </div>
+            <ExperienceSign />
           </div>
 
           {/* Right Content - Dashboard Image */}


### PR DESCRIPTION
## Summary
- replace experience badge in features section with hanging sign design
- add `ExperienceSign` component with SVG to replicate 35+ years industry sign

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4adbf15c0832fb194b26eaf450950