### PR TITLE
Improve experience banner layout

### DIFF
--- a/src/components/ExperienceSign.tsx
+++ b/src/components/ExperienceSign.tsx
@@ -30,10 +30,10 @@ const ExperienceSign = ({ className = "mx-auto mt-8 h-48 w-64" }: ExperienceSign
       strokeWidth="3"
     />
     <rect
-      x="20"
+      x="15"
       y="40"
-      width="160"
-      height="90"
+      width="170"
+      height="100"
       rx="8"
       fill="hsl(var(--card))"
       stroke="hsl(var(--muted-foreground))"
@@ -61,7 +61,7 @@ const ExperienceSign = ({ className = "mx-auto mt-8 h-48 w-64" }: ExperienceSign
     </text>
     <text
       x="100"
-      y="128"
+      y="134"
       textAnchor="middle"
       fontSize="14"
       fontWeight="600"

--- a/src/components/FeaturesSection.tsx
+++ b/src/components/FeaturesSection.tsx
@@ -84,7 +84,7 @@ const FeaturesSection = () => {
           </div>
 
           {/* Right Content - Dashboard Image with Experience Badge */}
-          <div className="relative">
+          <div className="relative mt-16">
             <Card className="overflow-hidden border-border/50 shadow-large">
               <img
                 src={constructionDashboard}
@@ -93,7 +93,7 @@ const FeaturesSection = () => {
               />
             </Card>
 
-            <div className="absolute -top-52 left-1/2 -translate-x-1/2">
+            <div className="absolute -top-40 left-1/2 -translate-x-1/2">
               <ExperienceSign className="h-48 w-64" />
             </div>
 


### PR DESCRIPTION
## Summary
- Lower dashboard image to give experience badge more breathing room
- Expand experience banner to prevent text from touching its edges

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4b4f14cbc832fb893bb98784165d2