### PR TITLE
Fix inconsistent project carousel image sizing

### DIFF
--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -20,7 +20,6 @@ import projectImg11 from "@/assets/projects/project-11.png";
 import projectImg12 from "@/assets/projects/project-12.png";
 import projectImg13 from "@/assets/projects/project-13.png";
 
-import { cn } from "@/lib/utils";
 
 function useAutoplay(api?: CarouselApi) {
   useEffect(() => {
@@ -151,10 +150,7 @@ const ProjectsSection = () => {
                     <img
                       src={image}
                       alt="Land project"
-                      className={cn(
-                        "w-full h-auto object-contain rounded-lg",
-                        idx === 1 && "max-h-96 w-auto"
-                      )}
+                      className="w-full h-full object-cover rounded-lg"
                     />
                   </CarouselItem>
                 ))}


### PR DESCRIPTION
## Summary
- remove custom sizing applied to second land image
- use uniform object-cover styling for land acquisition carousel images

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7080ddcd4832f87c2c9aefada99b8