### PR TITLE
Add demo link to projects page

### DIFF
--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -5,6 +5,18 @@ export default function Projects() {
   return (
     <AppLayout>
       <ProjectsSection />
+      <div className="container max-w-screen-2xl py-16">
+        <a
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            window.dispatchEvent(new CustomEvent("open-demo-modal"));
+          }}
+          className="block text-center text-lg sm:text-xl font-semibold text-ibuild-red hover:underline"
+        >
+          Learn More About Our Solutions - Schedule a Free Demo Today
+        </a>
+      </div>
     </AppLayout>
   );
 }


### PR DESCRIPTION
## Summary
- add centered demo link after single-family section on Projects page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c70da216b4832fbba504b9677e8ec6