### PR TITLE
feat: justify text across pages

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -6,7 +6,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen bg-background text-foreground">
       <Header />
-      <main>{children}</main>
+      <main className="px-4 text-justify">{children}</main>
       <Footer />
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -106,7 +106,7 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground text-justify;
   }
 
   /* Grid pattern background */

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,23 +1,17 @@
-import Header from "@/components/Header";
+import AppLayout from "@/components/layout/AppLayout";
 import HeroSection from "@/components/HeroSection";
 import AboutSection from "@/components/AboutSection";
 import TestimonialsSection from "@/components/TestimonialsSection";
 import FeaturesSection from "@/components/FeaturesSection";
-import Footer from "@/components/Footer";
 
-const Index = () => {
-  return (
-    <div className="min-h-screen bg-background">
-      <Header />
-      <main>
-        <HeroSection />
-        <AboutSection />
-        <TestimonialsSection />
-        <FeaturesSection />
-      </main>
-      <Footer />
-    </div>
-  );
-};
+const Index = () => (
+  <AppLayout>
+    <HeroSection />
+    <AboutSection />
+    <TestimonialsSection />
+    <FeaturesSection />
+  </AppLayout>
+);
 
 export default Index;
+

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,23 +1,32 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import AppLayout from "@/components/layout/AppLayout";
 
 const NotFound = () => {
   const location = useLocation();
 
   useEffect(() => {
-    console.error("404 Error: User attempted to access non-existent route:", location.pathname);
+    console.error(
+      "404 Error: User attempted to access non-existent route:",
+      location.pathname,
+    );
   }, [location.pathname]);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="mb-4 text-4xl font-bold">404</h1>
-        <p className="mb-4 text-xl text-gray-600">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 underline hover:text-blue-700">
-          Return to Home
-        </a>
+    <AppLayout>
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="max-w-md text-justify">
+          <h1 className="mb-4 text-4xl font-bold text-center">404</h1>
+          <p className="mb-4 text-xl text-gray-600">Oops! Page not found</p>
+          <a
+            href="/"
+            className="text-blue-500 underline hover:text-blue-700"
+          >
+            Return to Home
+          </a>
+        </div>
       </div>
-    </div>
+    </AppLayout>
   );
 };
 

--- a/src/pages/Tools.tsx
+++ b/src/pages/Tools.tsx
@@ -1,37 +1,34 @@
-import Header from "@/components/Header";
-import Footer from "@/components/Footer";
+import AppLayout from "@/components/layout/AppLayout";
 import { businessTools } from "@/content/tools";
 import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Building2 } from "lucide-react";
 
 const Tools = () => {
   return (
-    <div className="min-h-screen flex flex-col bg-background">
-      <Header />
-      <main className="flex-1">
-        <section className="py-16 bg-muted/30">
-          <div className="container max-w-screen-2xl">
-            <h2 className="text-3xl md:text-4xl font-bold text-center mb-12"> Our Business <span className="text-ibuild-red">Tools</span></h2>
-            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-              {businessTools.map((tool) => (
-                <Card key={tool.id} className="bg-card/60 backdrop-blur-sm border-border/50">
-                  <CardHeader className="flex flex-row gap-4">
-                    <div className="mt-1 flex h-10 w-10 items-center justify-center rounded-md bg-ibuild-red/10">
-                      <Building2 className="h-5 w-5 text-ibuild-red" />
-                    </div>
-                    <div>
-                      <CardTitle className="text-lg">{tool.name}</CardTitle>
-                      <CardDescription>{tool.description}</CardDescription>
-                    </div>
-                  </CardHeader>
-                </Card>
-              ))}
-            </div>
+    <AppLayout>
+      <section className="py-16 bg-muted/30">
+        <div className="container max-w-screen-2xl text-justify">
+          <h2 className="text-3xl md:text-4xl font-bold text-center mb-12">
+            Our Business <span className="text-ibuild-red">Tools</span>
+          </h2>
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {businessTools.map((tool) => (
+              <Card key={tool.id} className="bg-card/60 backdrop-blur-sm border-border/50">
+                <CardHeader className="flex flex-row gap-4">
+                  <div className="mt-1 flex h-10 w-10 items-center justify-center rounded-md bg-ibuild-red/10">
+                    <Building2 className="h-5 w-5 text-ibuild-red" />
+                  </div>
+                  <div>
+                    <CardTitle className="text-lg">{tool.name}</CardTitle>
+                    <CardDescription>{tool.description}</CardDescription>
+                  </div>
+                </CardHeader>
+              </Card>
+            ))}
           </div>
-        </section>
-      </main>
-      <Footer />
-    </div>
+        </div>
+      </section>
+    </AppLayout>
   );
 };
 


### PR DESCRIPTION
## Summary
- justify site text via global base styles
- use `AppLayout` for Index, Tools, and NotFound pages with responsive padding
- ensure page content defaults to justified alignment

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c716f32800832fbca2e2ebd25a08be