### PR TITLE
feat: organize tools page into sections

### DIFF
--- a/src/content/tools.ts
+++ b/src/content/tools.ts
@@ -5,95 +5,182 @@ export interface BusinessTool {
   slug: string;
 }
 
-export const businessTools: BusinessTool[] = [
+export interface BusinessToolSection {
+  id: string;
+  title: string;
+  tools: BusinessTool[];
+}
+
+export const toolSections: BusinessToolSection[] = [
   {
-    id: 'project-pro-forma-financial-forecasting',
-    name: 'Project Pro-Forma Financial Forecasting',
-    description: 'iBUILD’s forecasting tool is here to revolutionize your proforma investment financing process for procuring investment financing for your Mega Projects with Ultimate Simplifications, Rapid Insights, Comprehensive Cost Projections and Maintain Control.',
-    slug: 'project-pro-forma-financial-forecasting'
+    id: 'third-party-associates-management',
+    title:
+      "1. Enhancing Your Company’s Professional Image & Relationships With Your Third-Party Associates Management - Tools Section",
+    tools: [
+      {
+        id: 'project-proforma-financial-forecasting-management',
+        name: 'Project Proforma Financial Forecasting Management',
+        description:
+          'iBUILD’s Project Proforma Financial Forecasting tools remain a game changer in real estate financing, particularly for multi-family builds. By eliminating guesswork and streamlining strategies on investment projects’ cost projections, it not only fosters decision-making but also enhances credibility for third-party stakeholders. iBUILD gives project developers speed to securing capital they need with precision and confidence.',
+        slug: 'project-proforma-financial-forecasting-management'
+      },
+      {
+        id: 'associate-communication-portal-views-management',
+        name: 'Associate Communication Portal Views Management',
+        description:
+          'iBUILD’s Associate Communication Portal Views gives trades, suppliers, and investors real-time access to project updates, documents, and interdependent communication portals between suppliers, trades, marketing, finance, as well as direct communication links to building, city planning, and construction services. It empowers your business by strengthening communication ties, boosting transparency, and providing critical control over your relationships across every stage of development.',
+        slug: 'associate-communication-portal-views-management'
+      },
+      {
+        id: 'sales-customer-relations-portal-views-management',
+        name: 'Sales Customer Relations Portal Views Management',
+        description:
+          'iBUILD’s Sales Customer Relations Portal Views Management makes managing your client experience seamless. By integrating client portal views into the system, sales representatives can easily keep track of leads, discussions, and communications, providing transparency and instilling trust throughout the lifecycle. As a result, it boosts client relationships, improves team efficiency, and transforms your communications from reactive to proactive management.',
+        slug: 'sales-customer-relations-portal-views-management'
+      },
+      {
+        id: 'client-interior-exterior-selections-management',
+        name: 'Client Interior & Exterior Selections Management',
+        description:
+          'iBUILD’s Client Interior & Exterior Selections Management empowers homeowners to personalize every detail from exterior design, interior finishes, and amenities, to even selecting the foundation process. A smart, client-centered approach that removes your clients’ anxiety of full customization for their single-family or multi-family dream home.',
+        slug: 'client-interior-exterior-selections-management'
+      }
+    ]
   },
   {
-    id: 'associate-communication-process-flow',
-    name: 'Associate Communication Portal Views',
-    description: 'A captivating tool that is sure to impress your Clients, Trades, Suppliers, Investors/Bankers, and Lawyers with Enhance Your Professional Image, Delight Your Clients, Reduce Incoming Third-Party Communications and Boost Your Departmental Productivity',
-    slug: 'associate-communication-process-flow'
+    id: 'home-building-processes-management',
+    title:
+      '2. Simplifying Your Home Building Processes Management - Tools Section',
+    tools: [
+      {
+        id: 'job-creation-management',
+        name: 'Job Creation Management',
+        description:
+          'iBUILD’s Job Creation Management tool instantly generates job numbers and sets up all project components—whether for single-family homes, multi-family developments, or land ventures—saving you hours of manual data entry. With simplified client instructions, smooth workflows, and built-in administrative control, it empowers teams to launch projects with ease and the confidence of precision.',
+        slug: 'job-creation-management'
+      },
+      {
+        id: 'price-book-management',
+        name: 'Price Book Management',
+        description:
+          'iBUILD’s Price Book Management tool equips your sales team with pre-defined pricing for materials, labor, and components. It standardizes cost inputs, reduces errors, and enhances project budgeting efficiency. By simplifying client interaction and handling, it transforms pricing into a streamlined process of trust, speed, and satisfaction.',
+        slug: 'price-book-management'
+      },
+      {
+        id: 'changes-to-contract-management',
+        name: 'Changes To Contract (CTCs) Management',
+        description:
+          'iBUILD’s Changes To Contract (CTCs) Management tool streamlines any optional or mandatory client changes from the base building process. The Change To Contract (CTC) Management tool also aligns and automates change logs updates via the Client Portal. It ensures transparency, reduces ambiguity, and strengthens accountability with clear documentation.',
+        slug: 'changes-to-contract-management'
+      },
+      {
+        id: 'change-orders-management',
+        name: 'Change Orders (COs) Management',
+        description:
+          'iBUILD’s Change Orders (COs) Management tool streamlines client change requests by integrating real-time updates from the Price Book module and secure signature features. With instant access to signed COs via the Client Portal, it enhances transparency, reduces disputes, and strengthens contract flexibility.',
+        slug: 'change-orders-management'
+      },
+      {
+        id: 'vendor-master-file-management',
+        name: 'Vendor Master File Management',
+        description:
+          'iBUILD’s Vendor Master File Management tool is central to your operational efficiency, allowing for seamless organization and tracking of vendors, trades, and suppliers. A comprehensive database ties each vendor to project requirements, keeping information accessible and up-to-date, enabling smarter, timely decisions.',
+        slug: 'vendor-master-file-management'
+      },
+      {
+        id: 'estimating-quote-requests-contract-bidding-management',
+        name: 'Estimating Quote Requests (QR’s) Contract Bidding Management',
+        description:
+          'iBUILD’s Estimating Quote Requests (QRs) Contract Bidding Management tool automates every step of the quote management process—from bid creation to vendor evaluation—turning bid management into a quick, strategic advantage. It ensures accurate estimating, keeps projects on budget, and simplifies vendor comparisons, all within one cohesive system.',
+        slug: 'estimating-quote-requests-contract-bidding-management'
+      },
+      {
+        id: 'purchasing-pos-management',
+        name: 'Purchasing (POs) Management',
+        description:
+          'iBUILD’s Purchasing (POs) Management tool automates procurement by instantly converting winning bids into pre-coded purchase orders, which are emailed to vendors and seamlessly recorded in your accounting system. With real-time notifications and vendor portal access, it eliminates manual data entry while bringing transparency across your supply chain.',
+        slug: 'purchasing-pos-management'
+      },
+      {
+        id: 'construction-scheduling-monitoring-management',
+        name: 'Construction Scheduling & Monitoring Management',
+        description:
+          'iBUILD’s Construction Scheduling & Monitoring Management tools automate project timelines with customizable reports and schedules, real-time Gantt charts, and an integrated Task Management system for both on-site and remote teams. By equipping site supervisors with detailed scopes of work and proactive oversight tools, it transforms construction management into a streamlined, high-performance operation.',
+        slug: 'construction-scheduling-monitoring-management'
+      },
+      {
+        id: 'warranty-management',
+        name: 'Warranty Management',
+        description:
+          'iBUILD’s Warranty Management tool streamlines client service requests by enabling clients to submit warranty issues directly through their online portal. With automated notifications, prioritization of urgent cases, and comprehensive tracking, it builds trust, strengthens relationships, and turns satisfied clients into devoted advocates.',
+        slug: 'warranty-management'
+      }
+    ]
   },
   {
-    id: 'sales-customer-relations-management',
-    name: 'Sales Customer Relations Management',
-    description: 'A fundamental tool for streamlining client engagement with Transparent Communication, E-Signature Integration, Efficient Deposit Management and Seamless Experience',
-    slug: 'sales-customer-relations-management'
-  },
-  {
-    id: 'client-interior-exterior-selections-management',
-    name: 'Client Interior & Exterior Selections Management',
-    description: 'A dynamic component in creating homes that resonate with your clients’ desires with Interior Selections Only, Exterior & Interior Selections, Customization Empowerment and Seamless Management',
-    slug: 'client-interior-exterior-selections-management'
-  },
-  {
-    id: 'job-creation-management',
-    name: 'Job Creation Management',
-    description: 'This remarkable tool performs its wizardry by generating jobs in mere seconds, revolutionizing the way you create jobs / projects by Simplifies All Project Job Creation Processes, Project Flexibility Instant Job Creation and Seamless Project Initiation from Multi-Family Proformas',
-    slug: 'job-creation-management'
-  },
-  {
-    id: 'price-bid-management',
-    name: 'Price-Bid Management',
-    description: 'A central tool for efficient project management. Price Book Options and Assemblies: iBUILD provides you with comprehensive price book options and assemblies across major areas. Whether it’s materials, labor, or other project components, your sales staff find pre-approved and pre-defined pricing swiftly.',
-    slug: 'price-bid-management'
-  },
-    {
-    id: 'change-contract-management',
-    name: 'Changes To Contract (CTCs) Management',
-    description: 'A vital tool for streamlining a bulky selection of building materials by the client where Both your Client and your Builder Rep can sign off on changes electronically. It’s secure, efficient, and ensures a smooth finalization of contract modifications.',
-    slug: 'change-contract-management'
-  },
-  {
-    id: 'change-orders-management',
-    name: 'Change Orders (COs) Management',
-    description: 'A crucial tool for augmenting contract flexibility. Client Change Order details can also flow seamlessly from the Price Book Module. Change request processes flow quicker and smoother for both your Clients and your Sales Reps with Speedy E-Signature Integration',
-    slug: 'change-orders-management'
-  },
-  {
-    id: 'post-bid-management',
-    name: 'Estimating Quote Requests (QR’s) Contract Bidding Management',
-    description: 'Your strategic advantage in Vendor bidding management with Auto-Creation of Pre-defined Estimating Checklists, Automated Estimating, Real-Time Budget Updates, Automated Purchase Orders and Efficient Quote Request Management',
-    slug: 'post-bid-management'
-  },
-  {
-    id: 'construction-scheduling-tasking-management',
-    name: 'Construction Scheduling & Monitoring Management',
-    description: 'A critical tool for ensuring timely project execution with Automated Scheduling, Interactive Gantt Charts & Calendars, Empowering Site Supervisors and System Generated Detailed Scopes of Work',
-    slug: 'construction-scheduling-tasking-management'
-  },
-  {
-    id: 'warranty-management',
-    name: 'Warranty Management',
-    description: 'A fundamental tool for building trust and empowering relationships with Clients in your construction projects. Clients can initiate Warranty Service Requests right from their online Client Portal View. Warranty Management is immediately notified of all Clients incoming warranty requests ensuring all warranty matters are handled promptly and efficiently, especially for emergency situations.',
-    slug: 'warranty-management'
-  },
-  {
-    id: 'statement-of-adjustments-management',
-    name: 'Statement of Adjustments Management',
-    description: 'An indispensable tool for managing financial adjustments in real estate possession transactions with clarity. The automated SOA report outlines all financial adjustments related to the purchase or sale of a property, ensuring transparency and accuracy.',
-    slug: 'statement-of-adjustments-management'
-  },
-  {
-    id: 'wildCast-individual-global-notification-management',
-    name: 'WidCast Individual & Global Notifications Management',
-    description: 'This is a powerful tool for managing internal notifications efficiently. Within the settings or administration area, you can assign departmental predefined Task Notifications to specific individuals within a department. This targeted approach ensures that relevant notifications reach the right staff members promptly.',
-    slug: 'wildCast-individual-global-notification-management'
-  },
-  {
-    id: 'to-do',
-    name: 'To-Do',
-    description: 'Make it easy to create and assign tasks to your team and subcontractors. Keep them on track with automatic reminders, as well.',
-    slug: 'to-do'
-  },
-  {
-    id: 'discussion-feed',
-    name: 'Discussion Feed',
-    description: 'A vital tool for managing communication flows between one and one and group discussion on a task both internally and externally. Discussion Feed streamlines communication and keeps everyone informed and ensures that critical issues are discussed and brainstormed. It’s the heartbeat of efficient internal notifications! It also resolves all the He Said / She Said issues when they arise.',
-    slug: 'discussion-feed'
+    id: 'business-management-tools',
+    title:
+      '3. iBUILD’s Empowering Cutting-Edge Business Management Tools - Tools Section',
+    tools: [
+      {
+        id: 'document-auto-file-task-assignments-management',
+        name: 'Document Auto File Task Assignments Management',
+        description:
+          'iBUILD’s Document Auto File Task Assignments Management tool allows you to automate document-based tasks with intelligent project integration, ensuring nothing is overlooked. Each uploaded document automatically triggers predefined task assignments, providing cohesive project coordination, reducing errors, and increasing overall team efficiency.',
+        slug: 'document-auto-file-task-assignments-management'
+      },
+      {
+        id: 'financial-management-reporting-management',
+        name:
+          'Financial Management (Corporate, Development Portfolio, Project & Individual Properties) Reporting Management',
+        description:
+          'iBUILD’s Financial Management (Corporate, Development Portfolio, Project & Individual Properties) Reporting Management tool gives your finance department unparalleled insight into financial performance. Real-time dashboards, customizable reporting, and robust financial controls transform decision-making, ensuring accurate forecasting, regulatory compliance, and stakeholder trust.',
+        slug: 'financial-management-reporting-management'
+      },
+      {
+        id: 'project-management-templates-auto-load-management',
+        name: 'Project Management Templates with Auto Load Templates Management',
+        description:
+          'iBUILD’s Project Management Templates with Auto Load Templates Management tool provides over 150 customizable, industry-specific templates designed to streamline your project setup process. It saves time, enforces standardization, and enhances productivity across construction management phases—keeping every project consistent, compliant, and efficient.',
+        slug: 'project-management-templates-auto-load-management'
+      },
+      {
+        id: 'revenue-management-modules-tools-management',
+        name:
+          'iBuild’s Revenue Management Modules (including all Government Tax Collection Modules) Tools Management',
+        description:
+          'iBUILD’s Revenue Management Modules (including all Government Tax Collection Modules) Tools Management tool centralizes all revenue-related processes, integrating municipal, provincial/state, and federal tax collection modules. It ensures accurate billing, real-time auditing, and comprehensive revenue tracking—all within one secure, intuitive platform.',
+        slug: 'revenue-management-modules-tools-management'
+      },
+      {
+        id: 'statement-of-adjustments-management',
+        name: 'Statement Of Adjustments Management',
+        description:
+          'iBUILD’s Statement Of Adjustments Management tool is an indispensable tool for managing financial adjustments in real estate possession transactions with clarity. The automated SOA report outlines all financial adjustments related to the purchase or sale of a property, ensuring transparency and accuracy.',
+        slug: 'statement-of-adjustments-management'
+      },
+      {
+        id: 'wildcast-individual-global-notifications-management',
+        name: 'WildCast Individual & Global Notifications Management',
+        description:
+          'iBUILD’s WildCast Individual & Global Notifications Management is a powerful tool for managing internal notifications efficiently. Within the settings or administration area, you can assign departmental predefined task notifications to specific individuals within a department. This targeted approach ensures that relevant notifications reach the right staff members promptly.',
+        slug: 'wildcast-individual-global-notifications-management'
+      },
+      {
+        id: 'to-do',
+        name: 'To-Do',
+        description:
+          'iBUILD’s To-Do tool makes it easy to create and assign tasks to your team and subcontractors. Keep them on track with automatic reminders, as well.',
+        slug: 'to-do'
+      },
+      {
+        id: 'discussion-feed',
+        name: 'Discussion Feed',
+        description:
+          'iBUILD’s Discussion Feed is a vital tool for managing communication flows between one-on-one and group discussions on a task both internally and externally. Discussion Feed streamlines communication and keeps everyone informed and ensures that critical issues are discussed and brainstormed. It’s the heartbeat of efficient internal notifications! It also resolves all the He Said / She Said issues when they arise.',
+        slug: 'discussion-feed'
+      }
+    ]
   }
 ];
+

--- a/src/pages/Tools.tsx
+++ b/src/pages/Tools.tsx
@@ -1,5 +1,5 @@
 import AppLayout from "@/components/layout/AppLayout";
-import { businessTools } from "@/content/tools";
+import { toolSections } from "@/content/tools";
 import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Building2 } from "lucide-react";
 
@@ -8,24 +8,37 @@ const Tools = () => {
     <AppLayout>
       <section className="py-16 bg-muted/30">
         <div className="container max-w-screen-2xl text-justify">
-          <h2 className="text-3xl md:text-4xl font-bold text-center mb-12">
-            Our Business <span className="text-ibuild-red">Tools</span>
-          </h2>
-          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {businessTools.map((tool) => (
-              <Card key={tool.id} className="bg-card/60 backdrop-blur-sm border-border/50">
-                <CardHeader className="flex flex-row gap-4">
-                  <div className="mt-1 flex h-10 w-10 items-center justify-center rounded-md bg-ibuild-red/10">
-                    <Building2 className="h-5 w-5 text-ibuild-red" />
-                  </div>
-                  <div>
-                    <CardTitle className="text-lg">{tool.name}</CardTitle>
-                    <CardDescription>{tool.description}</CardDescription>
-                  </div>
-                </CardHeader>
-              </Card>
-            ))}
-          </div>
+          <h1 className="text-3xl md:text-4xl font-bold text-center mb-6">
+            iBUILD’s Innovative Construction & Business Digital Management Tools Aren’t Just Features — They’re Your Strategic Business Advantage
+          </h1>
+          <p className="text-center max-w-4xl mx-auto mb-12">
+            iBUILD’s tools are not mere functionalities but are core drivers of our competitive edge. By positioning them as strategic assets, it underscores how deeply digital integrated and automated systems can elevate operational efficiency, stakeholder trust, and decision-making—transforming construction management from reactive to proactive management.
+          </p>
+          {toolSections.map((section) => (
+            <div key={section.id} className="mb-12">
+              <h2 className="text-2xl md:text-3xl font-semibold text-center mb-8">
+                {section.title}
+              </h2>
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                {section.tools.map((tool) => (
+                  <Card
+                    key={tool.id}
+                    className="bg-card/60 backdrop-blur-sm border-border/50"
+                  >
+                    <CardHeader className="flex flex-row gap-4">
+                      <div className="mt-1 flex h-10 w-10 items-center justify-center rounded-md bg-ibuild-red/10">
+                        <Building2 className="h-5 w-5 text-ibuild-red" />
+                      </div>
+                      <div>
+                        <CardTitle className="text-lg">{tool.name}</CardTitle>
+                        <CardDescription>{tool.description}</CardDescription>
+                      </div>
+                    </CardHeader>
+                  </Card>
+                ))}
+              </div>
+            </div>
+          ))}
         </div>
       </section>
     </AppLayout>


### PR DESCRIPTION
## Summary
- structure tools page with introductory context and grouped tool sections
- expand tooling content to include detailed descriptions across three business categories

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7248c1338832fa472aba75b26e7da