### PR TITLE
Fix Tools page JSX structure

### DIFF
--- a/src/pages/Tools.tsx
+++ b/src/pages/Tools.tsx
@@ -12,8 +12,9 @@ const Tools = () => {
             iBUILD’s Innovative Construction & Business Digital Management Tools Aren’t Just Features — They’re Your Strategic Business Advantage
           </h1>
           <p className="text-center max-w-4xl mx-auto mb-12">
-           iBUILD’s tools are not mere functionalities but are core drivers of our competitive edge. By positioning them as strategic assets, it underscores how deeply digital integrated and automated systems can elevate operational efficiency, stakeholder trust, and decision-making—transforming construction management 
-            from reactive to proactive leadership.
+            iBUILD’s tools are not mere functionalities but are core drivers of our competitive edge. By positioning them as strategic assets, it underscores how deeply digital integrated and automated systems can elevate operational efficiency, stakeholder trust, and decision-making—transforming construction management from reactive to proactive leadership.
+          </p>
+          {toolSections.map((section) => (
             <div key={section.id} className="mb-12">
               <h2 className="text-2xl md:text-3xl font-semibold text-center mb-8">
                 {section.title}


### PR DESCRIPTION
## Summary
- close the introductory paragraph on the Tools page and properly iterate through tool sections
- render each tool with a card layout using mapped data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c75ab2183c832f8de345a0a2ac7df7