### PR TITLE
feat: default to dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark" data-bs-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/components/TestimonialsSection.tsx
+++ b/src/components/TestimonialsSection.tsx
@@ -82,7 +82,7 @@ const TestimonialsSection = () => {
           </h2>
           <p className="text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">
             At iBUILD – We Develop Relationships and Business Solutions, Not Just Software.<br />
-            At iBUILD, we don’t just deliver digital tools, we co-create solutions that strengthen partnerships, drive performance, and earn trust. Our clients value us not only for what we build, but for how we help them them <span className="text-ibuild-red">reduce operating costs, build smarter, track better, and deliver faster.</span>
+              At iBUILD, we don’t just deliver digital tools, we co-create solutions that strengthen partnerships, drive performance, and earn trust. Our clients value us not only for what we build, but for how we help them them <span className="text-ibuild-red">reduce operating costs, build smarter, track better, and deliver faster.</span>
           </p>
         </div>
 

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -34,18 +34,17 @@ export function ThemeProvider({
     const root = window.document.documentElement;
 
     root.classList.remove("light", "dark");
+    root.removeAttribute("data-bs-theme");
 
+    let resolvedTheme = theme;
     if (theme === "system") {
-      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
-        .matches
+      resolvedTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
         ? "dark"
         : "light";
-
-      root.classList.add(systemTheme);
-      return;
     }
 
-    root.classList.add(theme);
+    root.classList.add(resolvedTheme);
+    root.setAttribute("data-bs-theme", resolvedTheme);
   }, [theme]);
 
   const value = {


### PR DESCRIPTION
## Summary
- default site theme to dark in the base HTML
- ensure ThemeProvider sets and syncs Bootstrap theme attribute
- clean up irregular whitespace in testimonials section

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7ab07ac78832fa4cf8abc05a60656